### PR TITLE
Updated dart version for the snap

### DIFF
--- a/scripts/bashScripts/dartSdkDownload.sh
+++ b/scripts/bashScripts/dartSdkDownload.sh
@@ -14,7 +14,7 @@ case ${architecture} in
 		wget "${dartSdkPath}arm64-release.zip"	# For arm 64-bit
     ;; 
     ( "x64" | "x86_64" | "amd64" )
-    	wget  "${dartSdkPath}x64-release.zip"	# For linux intel 64-bit
+    	wget "${dartSdkPath}x64-release.zip"	# For linux intel 64-bit
     ;;
     ( "ia32" | "x86" | "i386"  )
     	wget "${dartSdkPath}ia32-release.zip"	# For linux intel 32-bit

--- a/scripts/bashScripts/dartSdkDownload.sh
+++ b/scripts/bashScripts/dartSdkDownload.sh
@@ -4,7 +4,7 @@ architecture="$(uname -m)"
 
 echo "architecture: ${architecture}"
 
-dartSdkPath="https://storage.googleapis.com/dart-archive/channels/stable/release/2.10.4/sdk/dartsdk-linux-"	# Sdk url: https://dart.dev/tools/sdk/archive
+dartSdkPath="https://storage.googleapis.com/dart-archive/channels/stable/release/2.12.2/sdk/dartsdk-linux-"	# Sdk url: https://dart.dev/tools/sdk/archive
 
 case ${architecture} in
 	( "arm" | "armv7l" )
@@ -14,7 +14,7 @@ case ${architecture} in
 		wget "${dartSdkPath}arm64-release.zip"	# For arm 64-bit
     ;; 
     ( "x64" | "x86_64" | "amd64" )
-    	wget "${dartSdkPath}x64-release.zip"	# For linux intel 64-bit
+    	wget  "${dartSdkPath}x64-release.zip"	# For linux intel 64-bit
     ;;
     ( "ia32" | "x86" | "i386"  )
     	wget "${dartSdkPath}ia32-release.zip"	# For linux intel 32-bit

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,6 +11,16 @@ description: |
 grade: stable  # devel/stable
 confinement: strict  # devmode/classic/strict
 
+architectures:
+  - build-on: armhf
+    run-on: armhf
+
+  - build-on: arm64
+    run-on: arm64
+
+  - build-on: amd64
+    run-on: amd64
+
 parts:
   security-bear:
     plugin: dump


### PR DESCRIPTION
Updated dart version for the snap.
Snap will now be built only for armhf, arm64, amd64